### PR TITLE
Make compile script work independently from where the repository is located

### DIFF
--- a/TRUMPOS/compile/compile_all.sh
+++ b/TRUMPOS/compile/compile_all.sh
@@ -2,7 +2,7 @@ cd
 cd barebones-toolchain
 . ./setenv.sh
 cd
-cd Desktop/TRUMPOS
+cd ../../TRUMPOS
 i686-elf-gcc -ffreestanding -Wall -Wextra -fno-builtin -nostdinc -I./include -std=gnu99 -nostdlib  -c kernel/main.c -o obj/main.o
 i686-elf-gcc -ffreestanding -Wall -Wextra -fno-builtin -nostdinc -I./include -std=gnu99 -nostdlib  -c kernel/vga/scrnlib.c -o obj/scrnlib.o
 i686-elf-gcc -ffreestanding -Wall -Wextra -fno-builtin -nostdinc -I./include -std=gnu99 -nostdlib  -c kernel/gdt.c -o obj/gdt.o


### PR DESCRIPTION
Currently, it only works if TRUMPOS is placed under Desktop/TrumpOS